### PR TITLE
Update 2.1.5

### DIFF
--- a/.metadata/changelog.txt
+++ b/.metadata/changelog.txt
@@ -228,4 +228,82 @@ Fixes:
 
 Event Relocations:
 balkfm.630 -> balkfm.640
-	
+
+--Update 2.1.4--
+**Updated for V3 1.7**
+New Additions:
+-New Opener journal "The Armansperg Regency" for Greece with event chain to introduce the Bavarocracy
+-Greek Revolts are now handled by je_grefm_greek_separatism
+-Revolts will now fire based off a mixture of radical_fraction and Greek support
+-New journal entry "The 14 Regions" representing the historic urbanization of Constantinople
+-New state trait "The Golden Horn" for Eastern Thrace
+
+Balancing/Adjustments:
+-Complete Teardown of "The Bavarocracy" journal and sub-content. The timeout is now a progress bar that drains monthly; this drain speed can be slowed down by completing the sub-journals
+	-Integrated the Bavarian Auxilliaries and Turk-Eater decisions as scripted buttons within the main Bavarocracy journal.
+	-Old Royal Palace is now available during the Bavarocracy journal chain instead of after abandoning the Byzantine Restoration
+	-Added new scripted button to get foreign loans
+	-New event "The Philorthodox Conspiracy" behaves like a grefm-specific version of eocfm.006
+	-Constitution modifiers also impact political strength on top of opinion.
+-Reworked the "Tyranny of House Wittelsbach" journal; The timeout is now a progress bar that depends on IG clout, enacted laws, and ruler popularity.
+-Reworked the completion requirements of "A Bavarian Greece"; it now behaves as an inverse Stamp Out Monarchy journal
+-The Megali Idea opening event now adds all claims at once; grefm.200/201 have been merged and the Treaty of Laussane option has been removed
+-Reworked events for Archaeology, some have been demoted to notifications and others have new options
+-Integrated the Mega Palation survey button into "The 14 Regions"
+-Removed Hippodrome survey
+-Greece/Byzantium monuments now longer appear in every state
+-Removed Cretan Revolt journals
+-Removed legacy Venizelism journal
+-Subsidizing the Church will now reduce their political strength
+-Caesaropapism now reduces Devout political strength by 25%
+-New option in grefm.031 in case you arrived via success in Bavarocracy Main
+-Added global notification in the event that a riot is suppressed
+-Suppressing a riot will reduce tension by 200
+-Hidden event added that can start the rioting event chain randomly any time Tension is over 400
+-eqfm rebellion effect now creates a dominion with an option to grant autonomy to bring it in line with how grefm rebellions behave
+
+Fixes:
+-"Comission Icon" button will now be disabled if the event is active
+-Stop Church Subsidies button is now visible regardless of your current amount of PA
+-Epirote Revolt event now snatches all Greek pops in Ottoman Albania and moves them to Epirote Albania
+-Fixed a trigger issue preventing the stop subsides button from appearing if you have don't have enough PA.
+-Deconfliction will now be correctly limited to Balkan uprisings
+-"Churches Burned in State" option now correctly deducts money
+-Adjusted rounding in some script values.
+-Kogalniceanu is now correctly freed from the void
+-Milos no longer wears a fez
+
+Event Relocations/Adjustments:
+je_grefm_the_dedilomeni_principle_otto_alternate -> je_grefm_bavarian_greece
+je_grefm_the_cretan_revolts -> deleted
+je_grefm_the_cretan_revolts_fallback -> deleted
+je_grefm_venizelism -> deleted
+grefm.009 -> grefm.030
+grefm.021 -> grefm.035
+grefm.022 -> grefm.029
+grefm.023 -> deleted
+grefm.030 -> grefm.031
+grefm.031 -> grefm.032
+grefm.032 -> grefm.033
+grefm.033 -> grefm.034
+grefm.200 -> merged with grefm.201 with new loc
+grefm.203 -> grefm.200
+grefm.204 -> grefm.203
+grefm.205 -> grefm.204
+grefm.210-12,15-18 -> reworked with new loc
+grefm.213-14 -> deleted
+grefm.219 -> deleted
+grefm.902-4 -> deleted
+grefm.905 -> grefm.902
+grefm.910-14 -> deleted
+grefm.915 -> grefm.219
+grefm.916 -> grefm.119
+
+--Update 2.1.5--
+Fixes/Adjustments:
+-Fixed Scripting for Revolt Buttons
+-Added ai_chance to the Greek Separatism buttons to avoid going bankrupt from supporting separatism
+-Fixed an incorrect variable trigger preventing the Turkish homelands event
+-14 Regions journal will be available immediately after forming BYZ/ERE
+-Option to Elect a member of House Ypsilantis to the greek throne has been switched to always appear
+-Option to abolish the monarchy in "An Elected Monarch" will enact Parliamentary Republic instead of Presidential. It still requires Egalitarianism to appear.

--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -2,7 +2,7 @@
   "name" : "Greece, Byzantium, & the Balkans Flavor",
   "picture" : "thumbnail.png",
   "id" : "3051891793",
-  "version" : "2.1.4",
+  "version" : "2.1.5",
   "supported_game_version" : "1.7.*",
   "short_description" : "",
   "tags" : [],

--- a/common/decisions/grefm_decisions.txt
+++ b/common/decisions/grefm_decisions.txt
@@ -45,13 +45,16 @@
 
 grefm_lake_kopais_decision = {
 	is_shown = {
-		has_variable = grefm_lake_kopais_option
 		NOT = { has_variable = grefm_lake_kopais_option_taken }
 		owns_entire_state_region = STATE_ATTICA
 	}
 	
 	possible = {	
 		owns_entire_state_region = STATE_ATTICA
+		has_technology_researched = hydraulic_cranes
+		hidden_trigger = {
+			has_variable = grefm_lake_kopais_option
+		}
 	}
 	
 	when_taken = {

--- a/common/journal_entries/balkfm.txt
+++ b/common/journal_entries/balkfm.txt
@@ -1462,7 +1462,7 @@ je_balkfm_bul_megali_idea = { # megali idea minus Attica and the Islands
 		trigger_event = {
 			id = balkfm.588 # The Queen of Cities
 		}
-		set_global_variable = grefm_megali_idea_completed
+		set_global_variable = grefm_megali_idea_complete
 	}
 	
 	invalid = {

--- a/common/journal_entries/byzfm.txt
+++ b/common/journal_entries/byzfm.txt
@@ -338,8 +338,6 @@ je_byzfm_the_purple_phoenix_central_italy = {
 # IMPERIAL AMIBITIONS #
 #######################
 
-## AMBITION JOURNALS ##
-
 je_byzfm_constantinople = { # 14 Regions of Constantinople
 	icon = "gfx/interface/icons/event_icons/event_eagle.dds"
 	
@@ -359,9 +357,8 @@ je_byzfm_constantinople = { # 14 Regions of Constantinople
 		capital = {
 			state_region = s:STATE_EASTERN_THRACE
 		}
-		custom_tooltip = {
-			text = je_byzfm_constantinople_tt
-			has_variable = byzfm_byzantium_restored
+		hidden_trigger = {
+			has_variable = byzfm_byzantium_formed
 		}
 	}
 	
@@ -507,3 +504,13 @@ je_byzfm_mega_palation_survey = {
 	should_be_pinned_by_default = yes
 	
 }
+
+#je_byzfm_byzantism = {
+#}
+#
+#je_byzfm_themata_system = {
+#}
+#
+#je_byzfm_divine_administration = {
+#}
+#

--- a/common/journal_entries/grefm.txt
+++ b/common/journal_entries/grefm.txt
@@ -1356,7 +1356,9 @@ je_grefm_megali_idea = {
 	}
 
 	on_complete = {
-		trigger_event = { id = grefm.202 } # option to convert to BYZ or remain as GRE
+		trigger_event = { 
+			id = grefm.202 # The Future of Greece
+		}
 	}
 	
 	invalid = {
@@ -1365,6 +1367,7 @@ je_grefm_megali_idea = {
 				has_variable = grefm_weaksauce
 				has_variable = byzfm_weaksauce
 				has_global_variable = has_formed_byz
+				has_global_variable = grefm_megali_idea_complete
 			}
 		}
 	}

--- a/common/scripted_buttons/grefm_scripted_buttons.txt
+++ b/common/scripted_buttons/grefm_scripted_buttons.txt
@@ -157,6 +157,42 @@ grefm_epirus_support_button = {
 		custom_tooltip = grefm_epirus_support_tt
 		add_modifier = modifier_grefm_supporting_epirus
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_epirus_cease_button = {
@@ -174,6 +210,34 @@ grefm_epirus_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_epirus
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_epirus_provoke_button = {
@@ -211,6 +275,11 @@ grefm_epirus_provoke_button = {
 				}
 			}
 		}
+		any_country = {
+			owns_entire_state_region = STATE_ALBANIA
+			owns_entire_state_region = STATE_THESSALIA
+			grefm_is_muslim_trigger = yes
+		}
 	}
 	
 	effect = {
@@ -230,9 +299,10 @@ grefm_epirus_provoke_button = {
 					limit = {
 						owns_entire_state_region = STATE_ALBANIA
 						owns_entire_state_region = STATE_THESSALIA
+						grefm_is_muslim_trigger = yes
 					}
 					trigger_event = {
-						id = grefm.215 # The Epirote Revolt (TUR/EGY)
+						id = grefm.911 # The Epirote Revolt (No Triggers)
 					}
 				}
 			}
@@ -242,6 +312,18 @@ grefm_epirus_provoke_button = {
 			months = normal_modifier_time
 		}
 		change_infamy = 5
+	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
 	}
 }
 	
@@ -270,6 +352,42 @@ grefm_macedonia_support_button = {
 		custom_tooltip = grefm_macedonia_support_tt
 		add_modifier = modifier_grefm_supporting_macedonia
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_macedonia_cease_button = {
@@ -287,6 +405,34 @@ grefm_macedonia_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_macedonia
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_macedonia_provoke_button = {
@@ -335,7 +481,7 @@ grefm_macedonia_provoke_button = {
 						owns_entire_state_region = STATE_MACEDONIA
 					}
 					trigger_event = {
-						id = grefm.217 # The Macedonian Revolt (TUR/EGY)
+						id = grefm.913 # The Macedonian Revolt (No Triggers)
 					}
 				}
 			}
@@ -346,6 +492,19 @@ grefm_macedonia_provoke_button = {
 		}
 		change_infamy = 5
 	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
+	}
+	
 }
 	
 grefm_skopia_support_button = {
@@ -373,6 +532,42 @@ grefm_skopia_support_button = {
 		custom_tooltip = grefm_skopia_support_tt
 		add_modifier = modifier_grefm_supporting_skopia
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_skopia_cease_button = {
@@ -390,6 +585,34 @@ grefm_skopia_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_skopia
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_skopia_provoke_button = {
@@ -438,7 +661,7 @@ grefm_skopia_provoke_button = {
 						owns_entire_state_region = STATE_SKOPIA
 					}
 					trigger_event = {
-						id = grefm.214 # The Makedonijan Revolt (TUR/EGY)
+						id = grefm.910 # The Makedonijan Revolt (No Triggers)
 					}
 				}
 			}
@@ -449,6 +672,19 @@ grefm_skopia_provoke_button = {
 		}
 		change_infamy = 5
 	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
+	}
+	
 }
 	
 grefm_smyrna_support_button = {
@@ -481,6 +717,42 @@ grefm_smyrna_support_button = {
 		custom_tooltip = grefm_smyrna_support_tt
 		add_modifier = modifier_grefm_supporting_smyrna
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_smyrna_cease_button = {
@@ -498,6 +770,34 @@ grefm_smyrna_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_smyrna
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_smyrna_provoke_button = {
@@ -551,7 +851,7 @@ grefm_smyrna_provoke_button = {
 						owns_entire_state_region = STATE_AYDIN
 					}
 					trigger_event = {
-						id = grefm.218 # The Smyrna Revolt (TUR/EGY)
+						id = grefm.914 # The Smyrnite Revolt (No Triggers)
 					}
 				}
 			}
@@ -562,6 +862,19 @@ grefm_smyrna_provoke_button = {
 		}
 		change_infamy = 5
 	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
+	}
+	
 }
 	
 grefm_cyprus_support_button = {
@@ -588,6 +901,42 @@ grefm_cyprus_support_button = {
 		custom_tooltip = grefm_cyprus_support_tt
 		add_modifier = modifier_grefm_supporting_cyprus
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_cyprus_cease_button = {
@@ -605,6 +954,34 @@ grefm_cyprus_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_cyprus
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_cyprus_provoke_button = {
@@ -653,7 +1030,7 @@ grefm_cyprus_provoke_button = {
 						owns_entire_state_region = STATE_CYPRUS
 					}
 					trigger_event = {
-						id = grefm.216 # The Cypriot Revolt (TUR/EGY)
+						id = grefm.912 # The Cypriot Revolt (No Triggers)
 					}
 				}
 				
@@ -665,6 +1042,19 @@ grefm_cyprus_provoke_button = {
 		}
 		change_infamy = 5
 	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
+	}
+	
 }
 	
 grefm_crete_support_button = {
@@ -691,6 +1081,42 @@ grefm_crete_support_button = {
 		custom_tooltip = grefm_crete_support_tt
 		add_modifier = modifier_grefm_supporting_crete
 	}
+	
+	ai_chance = {
+		base = -5
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+				OR = {
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = antagonize
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = conquer
+					}
+					has_secret_goal = {
+						who = c:TUR
+						secret_goal = dominate
+					}
+				}
+				weekly_net_fixed_income > money_amount_multiplier_medium
+				gold_reserves > 0
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = -1000
+		}
+	}
+	
 }
 
 grefm_crete_cease_button = {
@@ -708,6 +1134,34 @@ grefm_crete_cease_button = {
 	effect = {
 		remove_modifier = modifier_grefm_supporting_crete
 	}
+	
+	ai_chance = {
+		base = 0
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root > relations_threshold:neutral
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			trigger = {
+				weekly_net_fixed_income < money_amount_multiplier_medium
+				gold_reserves < 0
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 grefm_crete_provoke_button = {
@@ -764,6 +1218,19 @@ grefm_crete_provoke_button = {
 		}
 		change_infamy = 5
 	}
+	
+	ai_chance = {
+		base = -100
+		modifier = {
+			trigger = {
+				c:TUR ?= {
+					relations:root < relations_threshold:neutral
+				}
+			}
+			add = 1000
+		}
+	}
+	
 }
 
 # ARCHEAOLOGY

--- a/events/byzfm_events.txt
+++ b/events/byzfm_events.txt
@@ -104,6 +104,7 @@ namespace = byzfm
 
 byzfm.100 = { # The 14 Regions of Constantinople
 	type = country_event
+	placement = scope:eastern_thrace_state_scope
 	
 	title = byzfm.100.t
 	desc = byzfm.100.d
@@ -152,7 +153,7 @@ byzfm.101 = { # Imperial Palace Ruins Identified
 	desc = byzfm.101.d
 	flavor = byzfm.101.f
 
-	placement = scope:mega_palation_site
+	placement = scope:eastern_thrace_state_scope
 
 	event_image = {
 		video = "middleeast_engineer_blueprint"
@@ -199,7 +200,7 @@ byzfm.102 = { # Great Palace of Constantinople
 	desc = byzfm.102.d
 	flavor = byzfm.102.f
 	
-	placement = scope:mega_palation_site
+	placement = scope:eastern_thrace_state_scope
 	
 	event_image = {
 		video = "unspecific_world_fair"
@@ -253,7 +254,7 @@ byzfm.103 = { # The Hippodrome of Constantinople
 	desc = byzfm.103.d
 	flavor = byzfm.103.f
 	
-	placement = scope:byzantium_capital_state
+	placement = scope:eastern_thrace_state_scope
 	
 	event_image = {
 		video = "byzfm_ruins"

--- a/events/grefm_events.txt
+++ b/events/grefm_events.txt
@@ -259,6 +259,13 @@ namespace = grefm
 #	901 - Adds Mainland Greece claims to non-GRE Greek nations
 #	902 - Reassigns Revolt Journals
 
+#910-910 - Technical Events
+#	910 - The Makedonijan Revolt (No Triggers)
+#   911 - The Epirote Revolt (No Triggers)
+#	912 - The Cypriot Revolt (No Triggers)
+#	913 - The Macedonian Revolt (No Triggers)
+#	914 - The Smyrnite Revolt (No Triggers)
+
 ############################
 
 
@@ -2468,8 +2475,7 @@ grefm.030 = { # 1862 head of state referendum
 	
 	option = { # Ypsilantis, the Phanariote option - votes were cast in favor of an unspecfied Ypsilantis noble
 		name = grefm.030.4
-		trigger = {
-			has_law = law_type:law_hereditary_bureaucrats
+		trigger = { # Always Available
 		}
 		custom_tooltip = {
 			text = grefm.030.4.tt
@@ -2487,10 +2493,28 @@ grefm.030 = { # 1862 head of state referendum
 						arrogant
 					}
 					on_created = {
-#						set_variable = grefm_phanariot
+						set_variable = grefm_phanariot
 						set_character_as_ruler = yes
 					}
 				}
+			}
+		}
+		c:GBR ?= {
+			change_relations = {
+				country = root
+				value = -25
+			}
+		}
+		c:FRA ?= {
+			change_relations = {
+				country = root
+				value = -25
+			}
+		}
+		c:RUS ?= {
+			change_relations = {
+				country = root
+				value = -25
 			}
 		}
 		trigger_event = {
@@ -2534,7 +2558,7 @@ grefm.030 = { # 1862 head of state referendum
 		trigger = {
 			has_technology_researched = egalitarianism
 		}
-		activate_law = law_type:law_presidential_republic
+		activate_law = law_type:law_parliamentary_republic
 		trigger_event = {
 			id = grefm.005 # convenient for cleanup, flavor, and damaging relations
 			popup = yes
@@ -9258,11 +9282,19 @@ grefm.260 = { # the fate of the turks
 	dlc = dlc_grefm
 
 	trigger = {
-		has_variable = grefm_megali_idea_completed
-		has_technology_researched = civilizing_mission
 		NOT = {	has_variable = grefm_greek_homelands_event }
+		has_global_variable = grefm_megali_idea_complete
+		any_scope_state = {
+			state_region = {
+				AND = {
+					is_homeland = cu:turkish
+					is_homeland = cu:greek
+				}
+			}
+		}
+		has_technology_researched = civilizing_mission
 	}
-		
+	
 	immediate = {
 		set_variable = grefm_greek_homelands_event
 	}
@@ -10426,6 +10458,9 @@ grefm.901 = { # adds claims to greek countries if they go independent
 	hidden = yes
 	
 	trigger = {
+		country_has_primary_culture = cu:greek
+		NOT = { has_variable = grefm_mainland_claims_added }
+		is_subject = no
 		NOR = {
 			exists = c:GRE
 			exists = c:BYZ
@@ -10434,9 +10469,6 @@ grefm.901 = { # adds claims to greek countries if they go independent
 			exists = c:HEMP
 			exists = c:ODXY
 		}
-		NOT = { has_variable = grefm_mainland_claims_added }
-		country_has_primary_culture = cu:greek
-		is_subject = no
 	}
 	
 	immediate = {
@@ -10508,6 +10540,624 @@ grefm.902 = { # hidden event triggering the Don Pacifico Affair
 			}
 		}
 		remove_variable = grefm_don_pacifico_var
+	}
+	
+}
+
+#### TECHNICAL EVENTS ####
+
+grefm.910 = { # The Makedonijan Revolt (No Triggers)
+	type = country_event
+	placement = scope:skopia_state_scope
+	
+	title = grefm.214.t
+	desc = grefm.214.d
+	flavor = grefm.214.f
+	
+	event_image = {
+		video = "europenorthamerica_springtime_of_nations"
+	}
+
+	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
+
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+
+	duration = 3
+	
+	dlc = dlc_grefm
+
+	trigger = {
+		# triggered by grefm_skopia_provoke_button
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = grefm_revolt_cooldown
+			days = 720
+		}
+		s:STATE_SKOPIA = {
+			random_scope_state = {
+				save_scope_as = skopia_state_scope
+			}
+		}
+		create_country = {
+			tag = NMAC
+			origin = this
+			state = scope:skopia_state_scope
+		}
+		c:NMAC = {
+			save_scope_as = makedonija_scope
+			set_variable = grefm_revolt_tracker
+		}
+		create_diplomatic_pact = {
+			country = c:NMAC
+			type = dominion
+		}
+		create_bidirectional_truce = {
+			country = c:NMAC
+			months = 60
+		}
+		grefm_greek_revolt_tension_effect = yes
+		set_variable = grefm_owner_tracker
+	}
+		
+	option = { # Get the Whip
+		name = grefm.214.a
+		default_option = yes
+		c:NMAC = {
+			make_independent = yes
+		}
+		end_truce = c:NMAC
+		create_diplomatic_play = {
+			name = grefm_epirus_rebellion
+			target_country = c:NMAC
+			type = dp_secession
+		}
+		hidden_effect = {
+			random_diplomatic_play = {
+				limit = {
+					ROOT = {
+						is_diplomatic_play_initiator = yes
+					}
+					c:NMAC = {
+						is_diplomatic_play_target = yes
+					}
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_SKOPIA.region_state:NMAC
+				}
+				add_war_goal = {
+					holder = c:NMAC
+					type = independence
+				}
+				add_diplomatic_play_war_support = {
+					target = c:NMAC
+					value = 100
+				}
+			}
+			change_infamy = -5
+		}
+		every_country = {
+			limit = {
+				country_has_primary_culture = cu:greek
+			}
+			trigger_event = {
+				id = grefm.212 # Greek Uprising in State (GRE)
+			}
+		}
+	}
+	
+	option = { # Give them Autonomy
+		name = grefm.214.b
+		add_modifier = {
+			name = modifier_grefm_granted_balkan_autonomy
+			months = normal_modifier_time
+			is_decaying = yes
+		}
+		create_diplomatic_pact = {
+			country = c:NMAC
+			type = protectorate
+		}
+	}
+	
+}
+
+grefm.911 = { # The Epirote Revolt (No Triggers)
+	type = country_event
+	placement = scope:albania_state_scope
+	
+	title = grefm.215.t
+	desc = grefm.215.d
+	flavor = grefm.215.f
+	
+	event_image = {
+		video = "europenorthamerica_springtime_of_nations"
+	}
+
+	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
+
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+
+	duration = 3
+	
+	dlc = dlc_grefm
+
+	trigger = {
+		# triggered from grefm_epirus_provoke_button
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = grefm_revolt_cooldown
+			days = 720
+		}
+		s:STATE_ALBANIA = {
+			random_scope_state = {
+				save_scope_as = albania_state_scope
+			}
+		}
+		create_country = {
+			tag = EPI
+			origin = this
+			province = p:xC42EC6
+			province = p:x7BE071
+			province = p:x18C9AD
+			province = p:x01D0E0
+			province = p:x8050E0
+			on_created = {
+			}
+		}
+		c:EPI = {
+			save_scope_as = epirus_scope
+			create_epirus_characters = yes
+			set_variable = grefm_revolt_tracker
+		}
+		create_diplomatic_pact = {
+			country = c:EPI
+			type = dominion
+		}
+		create_bidirectional_truce = {
+			country = c:EPI
+			months = 60
+		}
+		random_scope_state = {
+			limit = {
+				state_region = s:STATE_ALBANIA
+			}
+			every_scope_pop = {
+				limit = {
+					culture = cu:greek
+				}
+				move_pop = s:STATE_ALBANIA.region_state:EPI
+			}
+		}
+		grefm_greek_revolt_tension_effect = yes
+		set_variable = grefm_owner_tracker
+	}
+	
+	option = { # Get the Whip
+		name = grefm.215.a
+		default_option = yes
+		c:EPI = {
+			make_independent = yes
+		}
+		end_truce = c:EPI
+		create_diplomatic_play = {
+			name = grefm_epirus_rebellion
+			target_country = c:EPI
+			type = dp_secession
+		}
+		hidden_effect = {
+			random_diplomatic_play = {
+				limit = {
+					ROOT = {
+						is_diplomatic_play_initiator = yes
+					}
+					c:EPI = {
+						is_diplomatic_play_target = yes
+					}
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_ALBANIA.region_state:EPI
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_THESSALIA.region_state:EPI
+				}
+				add_war_goal = {
+					holder = c:EPI
+					type = independence
+				}
+				add_diplomatic_play_war_support = {
+					target = c:EPI
+					value = 100
+				}
+			}
+			change_infamy = -10
+		}
+		every_country = {
+			limit = {
+				country_has_primary_culture = cu:greek
+			}
+			trigger_event = {
+				id = grefm.212 # Greek Uprising in State (GRE)
+			}
+		}
+	}
+	
+	option = { # Give them Autonomy
+		name = grefm.215.b
+		add_modifier = {
+			name = modifier_grefm_granted_balkan_autonomy
+			months = normal_modifier_time
+			is_decaying = yes
+		}
+		create_diplomatic_pact = {
+			country = c:EPI
+			type = protectorate
+		}
+	}
+	
+}
+
+grefm.912 = { # The Cypriot Revolt (No Triggers)
+	type = country_event
+	placement = scope:cyprus_state_scope
+	
+	title = grefm.216.t
+	desc = grefm.216.d
+	flavor = grefm.216.f
+	
+	event_image = {
+		video = "europenorthamerica_springtime_of_nations"
+	}
+
+	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
+
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+
+	duration = 3
+	
+	dlc = dlc_grefm
+
+	trigger = {
+		# triggered from grefm_cyprus_provoke_button
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = grefm_revolt_cooldown
+			days = 720
+		}
+		s:STATE_CYPRUS = {
+			random_scope_state = {
+				save_scope_as = cyprus_state_scope
+			}
+		}
+		create_country = {
+			tag = CYP
+			origin = this
+			state = scope:cyprus_state_scope
+		}
+		c:CYP = {
+			save_scope_as = cyprus_scope
+			create_cyprus_characters = yes
+			set_variable = grefm_revolt_tracker
+		}
+		create_diplomatic_pact = {
+			country = c:CYP
+			type = dominion
+		}
+		create_bidirectional_truce = {
+			country = c:CYP
+			months = 60
+		}
+		grefm_greek_revolt_tension_effect = yes
+		set_variable = grefm_owner_tracker		
+	}	
+		
+	option = { # Get the Whip
+		name = grefm.216.a
+		default_option = yes
+		c:CYP = {
+			make_independent = yes
+		}
+		end_truce = c:CYP
+		create_diplomatic_play = {
+			name = grefm_cyprus_rebellion
+			target_country = c:CYP
+			type = dp_secession
+		}
+		hidden_effect = {
+			random_diplomatic_play = {
+				limit = {
+					ROOT = {
+						is_diplomatic_play_initiator = yes
+					}
+					c:CYP = {
+						is_diplomatic_play_target = yes
+					}
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_CYPRUS.region_state:CYP
+				}
+				add_war_goal = {
+					holder = c:CYP
+					type = independence
+				}
+				add_diplomatic_play_war_support = {
+					target = c:CYP
+					value = 100
+				}
+			}
+			change_infamy = -5
+		}
+		hidden_effect = {
+			every_country = {
+				limit = {
+					country_has_primary_culture = cu:greek
+				}
+				trigger_event = {
+					id = grefm.212 # Greek Uprising in State (GRE)
+				}
+			}
+		}
+	}
+	
+	option = { # Give them Autonomy
+		name = grefm.216.b
+		add_modifier = {
+			name = modifier_grefm_granted_balkan_autonomy
+			months = normal_modifier_time
+			is_decaying = yes
+		}
+		create_diplomatic_pact = {
+			country = c:CYP
+			type = protectorate
+		}
+	}
+	
+}
+
+grefm.913 = { # The Macedonian Revolt (No Triggers)
+	type = country_event
+	placement = scope:macedonia_state_scope
+	
+	title = grefm.217.t
+	desc = grefm.217.d
+	flavor = grefm.217.f
+	
+	event_image = {
+		video = "europenorthamerica_springtime_of_nations"
+	}
+
+	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
+
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+
+	duration = 3
+	
+	dlc = dlc_grefm
+
+	trigger = {
+		# triggered from grefm_macedonia_provoke_button
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = grefm_revolt_cooldown
+			days = 720
+		}
+		s:STATE_MACEDONIA = {
+			random_scope_state = {
+				save_scope_as = macedonia_state_scope
+			}
+		}
+		create_country = {
+			tag = MAC
+			origin = this
+			state = scope:macedonia_state_scope
+		}
+		c:MAC = {
+			save_scope_as = macedonia_scope
+			set_variable = grefm_revolt_tracker
+		}
+		create_diplomatic_pact = {
+			country = c:MAC
+			type = dominion
+		}
+		create_bidirectional_truce = {
+			country = c:MAC
+			months = 60
+		}
+		grefm_greek_revolt_tension_effect = yes
+		set_variable = grefm_owner_tracker
+	}
+		
+	option = { # Get the Whip
+		name = grefm.217.a
+		default_option = yes
+		c:MAC = {
+			make_independent = yes
+		}
+		end_truce = c:MAC
+		create_diplomatic_play = {
+			name = grefm_epirus_rebellion
+			target_country = c:MAC
+			type = dp_secession
+		}
+		hidden_effect = {
+			random_diplomatic_play = {
+				limit = {
+					ROOT = {
+						is_diplomatic_play_initiator = yes
+					}
+					c:MAC = {
+						is_diplomatic_play_target = yes
+					}
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_MACEDONIA.region_state:MAC
+				}
+				add_war_goal = {
+					holder = c:MAC
+					type = independence
+				}
+				add_diplomatic_play_war_support = {
+					target = c:MAC
+					value = 100
+				}
+			}
+			change_infamy = -5
+		}
+		every_country = {
+			limit = {
+				country_has_primary_culture = cu:greek
+			}
+			trigger_event = {
+				id = grefm.212 # Greek Uprising in State (GRE)
+			}
+		}
+	}
+	
+	option = { # Give them Autonomy
+		name = grefm.217.b
+		add_modifier = {
+			name = modifier_grefm_granted_balkan_autonomy
+			months = normal_modifier_time
+			is_decaying = yes
+		}
+		create_diplomatic_pact = {
+			country = c:MAC
+			type = protectorate
+		}
+	}
+	
+}
+
+grefm.914 = { # The Smyrna Revolt (No Triggers)
+	type = country_event
+	placement = scope:aydin_state_scope
+	
+	title = grefm.218.t
+	desc = grefm.218.d
+	flavor = grefm.218.f
+	
+	event_image = {
+		video = "europenorthamerica_springtime_of_nations"
+	}
+
+	on_created_soundeffect = "event:/SFX/UI/Alerts/event_appear"
+
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+
+	duration = 3
+	
+	dlc = dlc_grefm
+
+	trigger = {
+		# triggered from grefm_smyrna_provoke_button
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = grefm_revolt_cooldown
+			days = 720
+		}
+		s:STATE_AYDIN = {
+			random_scope_state = {
+				save_scope_as = aydin_state_scope
+			}
+		}
+		create_country = {
+			tag = SMYR
+			origin = this
+			state = scope:aydin_state_scope
+		}
+		c:SMYR = {
+			save_scope_as = smyrna_scope
+			set_variable = grefm_revolt_tracker
+		}
+		create_diplomatic_pact = {
+			country = c:SMYR
+			type = dominion
+		}
+		create_bidirectional_truce = {
+			country = c:SMYR
+			months = 60
+		}
+		grefm_greek_revolt_tension_effect = yes
+		set_variable = grefm_owner_tracker
+	}
+		
+	option = { # Get the Whip
+		name = grefm.218.a
+		default_option = yes
+		c:SMYR = {
+			make_independent = yes
+		}
+		end_truce = c:SMYR
+		create_diplomatic_play = {
+			name = grefm_epirus_rebellion
+			target_country = c:SMYR
+			type = dp_secession
+		}
+		hidden_effect = {
+			random_diplomatic_play = {
+				limit = {
+					ROOT = {
+						is_diplomatic_play_initiator = yes
+					}
+					c:SMYR = {
+						is_diplomatic_play_target = yes
+					}
+				}
+				add_war_goal = {
+					holder = root
+					type = return_state
+					target_state = s:STATE_AYDIN.region_state:SMYR
+				}
+				add_war_goal = {
+					holder = c:SMYR
+					type = independence
+				}
+				add_diplomatic_play_war_support = {
+					target = c:SMYR
+					value = 100
+				}
+			}
+			change_infamy = -5
+		}
+		every_country = {
+			limit = {
+				country_has_primary_culture = cu:greek
+			}
+			trigger_event = {
+				id = grefm.212 # Greek Uprising in State (GRE)
+			}
+		}
+	}
+	
+	option = { # Give them Autonomy
+		name = grefm.218.b
+		add_modifier = {
+			name = modifier_grefm_granted_balkan_autonomy
+			months = normal_modifier_time
+			is_decaying = yes
+		}
+		create_diplomatic_pact = {
+			country = c:SMYR
+			type = protectorate
+		}
 	}
 	
 }


### PR DESCRIPTION
-Fixed Scripting for Revolt Buttons
-Added ai_chance to the Greek Separatism buttons to avoid going bankrupt from supporting separatism
-Fixed an incorrect variable trigger preventing the Turkish homelands event
-14 Regions journal will be available immediately after forming BYZ/ERE
-Option to Elect a member of House Ypsilantis to the greek throne has been switched to always appear
-Option to abolish the monarchy in "An Elected Monarch" will enact Parliamentary Republic instead of Presidential. It still requires Egalitarianism to appear.
-Fixed placement scope problems in byzfm.10X events