### PR TITLE
Castlelul Peles Hotfix

### DIFF
--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -2,7 +2,7 @@
   "name" : "Greece, Byzantium, & the Balkans Flavor",
   "picture" : "thumbnail.png",
   "id" : "3051891793",
-  "version" : "2.1.5",
+  "version" : "2.1.6",
   "supported_game_version" : "1.7.*",
   "short_description" : "",
   "tags" : [],

--- a/common/decisions/balkfm_decisions.txt
+++ b/common/decisions/balkfm_decisions.txt
@@ -2,14 +2,12 @@
 	is_shown = {
 		c:ROM ?= this
 		owns_entire_state_region = STATE_WALLACHIA
-		any_scope_building = {
-			NOT = {
+		NOR = {
+			any_scope_building = {
 				is_building_type = building_castelul_peles
 			}
-		}
-		NOT = {
 			has_journal_entry = je_balkfm_peles_castle
-		}		
+		}
 	}
 	
 	possible = {	
@@ -27,5 +25,30 @@
 	
 	ai_chance = {
 		base = 0
+	}
+}
+
+balkfm_clear_construction_modifiers_decision = {
+	is_shown = {
+		OR = {
+			has_modifier = modifier_balkfm_construction_1
+			has_modifier = modifier_balkfm_construction_2
+			has_modifier = modifier_balkfm_construction_3
+		}
+		NOR = {
+			has_journal_entry = je_balkfm_peles_castle
+		}		
+	}
+	
+	possible = {	
+		always = yes
+	}
+	
+	when_taken = {
+		balkfm_clean_up_construction_effect = yes
+	}
+	
+	ai_chance = {
+		base = 100
 	}
 }

--- a/common/journal_entries/balkfm.txt
+++ b/common/journal_entries/balkfm.txt
@@ -2700,6 +2700,7 @@ je_balkfm_peles_castle = {
 		trigger_event = {
 			id = balkfm.661 # A Royal Estate
 		}
+		balkfm_clean_up_construction_effect = yes
 	}
 	
 	fail = {

--- a/localization/english/balkfm_l_english.yml
+++ b/localization/english/balkfm_l_english.yml
@@ -222,6 +222,8 @@
  # decisions
  balkfm_peles_castle_decision: "Build the Peleș Castle"
  balkfm_peles_castle_decision_desc: "Romania has finally forged a union between the Principalities. The King has proposed the construction of a royal estate with the aim of securing legitimacy and prestige for the young nation."
+ balkfm_clear_construction_modifiers_decision: "Clear Construction Modifiers"
+ balkfm_clear_construction_modifiers_decision_desc: "This is a fallback decision to remove the construction penalities should they get stuck."
  
  # tooltips
  je_balkfm_construction_0: "Construction is stalled."


### PR DESCRIPTION
-Construction Journal now removes construction penalties on completion instead of only on failure.
-Added fallback decision to remove the construction penalties in case they get stuck. 
-Fixed bad trigger structure checking for the existence of the Peles Castle