### PR TITLE
Update 2.3.5

### DIFF
--- a/common/country_definitions/grefm_countries.txt
+++ b/common/country_definitions/grefm_countries.txt
@@ -22,6 +22,30 @@ BYZ = {
 	capital = STATE_EASTERN_THRACE
 }
 
+CRE = {
+	color = { 165  111  159 }
+	
+	country_type = recognized
+
+	tier = principality
+	
+	cultures = { hellene }
+	capital = STATE_CRETE
+	is_named_from_capital = yes
+}
+
+CYP = {
+	color = { 78  75  39 }
+	
+	country_type = recognized
+
+	tier = principality
+	
+	cultures = { hellene }
+	capital = STATE_CYPRUS
+	is_named_from_capital = yes
+}
+
 EPI = {
 	color = { 0  91  174 }
 	
@@ -31,6 +55,17 @@ EPI = {
 	
 	cultures = { hellene }
 	capital = STATE_ALBANIA
+}
+
+GRE = {
+	color = { 122  180  210 }
+	
+	country_type = recognized
+
+	tier = kingdom
+	
+	cultures = { hellene }	
+	capital = STATE_ATTICA
 }
 
 HEMP = {
@@ -43,6 +78,19 @@ HEMP = {
 	cultures = { hellene }
 	capital = STATE_MACEDONIA
 }
+
+ION = {
+	color = { 153  141  117 }
+	
+	country_type = recognized
+
+	tier = principality
+	
+	cultures = { hellene }	
+	capital = STATE_IONIAN_ISLANDS
+	is_named_from_capital = yes
+}
+
 
 MAC = {
 	color = { 0  48  102 }

--- a/common/scripted_buttons/grefm_scripted_buttons.txt
+++ b/common/scripted_buttons/grefm_scripted_buttons.txt
@@ -340,6 +340,9 @@ grefm_embrace_hellenic_identity_button = {
 				var:grefm_hellene_culture_var >= 10
 			}
 		}
+		NOT = {
+			has_variable = grefm_culture_var
+		}
 	}
 	
 	effect = {
@@ -373,6 +376,9 @@ grefm_embrace_roman_identity_button = {
 				has_variable = grefm_rhomaios_culture_var
 				var:grefm_rhomaios_culture_var >= 10
 			}
+		}
+		NOT = {
+			has_variable = grefm_culture_var
 		}
 	}
 	
@@ -414,6 +420,9 @@ grefm_embrace_hybrid_identity_button = {
 				has_variable = grefm_rhomaios_culture_var
 				var:grefm_rhomaios_culture_var >= 10
 			}
+		}
+		NOT = {
+			has_variable = grefm_culture_var
 		}
 	}
 	

--- a/events/grefm_events.txt
+++ b/events/grefm_events.txt
@@ -2900,7 +2900,10 @@ grefm.031 = { # the king of the hellenes
 		triggered_desc = {
 			desc = grefm.031.d2
 			trigger = {
-				has_variable = grefm_bavarocracy_secured
+				OR = {
+					has_variable = grefm_bavarocracy_secured
+					has_variable = grefm_bavarianism_var
+				}
 			}
 		}
 		triggered_desc = {
@@ -2909,6 +2912,7 @@ grefm.031 = { # the king of the hellenes
 				NOR = {
 					has_variable = grefm_1862_election_held
 					has_variable = grefm_bavarocracy_secured
+					has_variable = grefm_bavarianism_var
 				}
 			}
 		}
@@ -2978,7 +2982,10 @@ grefm.031 = { # the king of the hellenes
 	option = { # Alternate if you got here via grefm.007 # Mandate Secured
 		name = grefm.031.a
 		trigger = {
-			has_variable = grefm_bavarocracy_secured
+			OR = {
+				has_variable = grefm_bavarocracy_secured
+				has_variable = grefm_bavarianism_var
+			}
 		}
 		ruler = {
 			add_trait = trait_grefm_absolutist_ruler
@@ -5695,49 +5702,49 @@ grefm.144 = { # Roman Excavation Completed
 	
 	title = {
 		triggered_desc = {
-			desc = grefm.143.t1
+			desc = grefm.144.t1
 			trigger = {
 				has_variable = grefm_corinth_1_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t2
+			desc = grefm.144.t2
 			trigger = {
 				has_variable = grefm_corinth_2_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t3
+			desc = grefm.144.t3
 			trigger = {
 				has_variable = grefm_thessaloniki_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t4
+			desc = grefm.144.t4
 			trigger = {
 				has_variable = grefm_thebes_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t5
+			desc = grefm.144.t5
 			trigger = {
 				has_variable = grefm_nicomedia_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t6
+			desc = grefm.144.t6
 			trigger = {
 				has_variable = grefm_smyrna_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t7
+			desc = grefm.144.t7
 			trigger = {
 				has_variable = grefm_tyana_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.t8
+			desc = grefm.144.t8
 			trigger = {
 				has_variable = grefm_chios_excavation
 			}
@@ -5745,49 +5752,49 @@ grefm.144 = { # Roman Excavation Completed
 	}
 	desc = {
 		triggered_desc = {
-			desc = grefm.143.d1
+			desc = grefm.144.d1
 			trigger = {
 				has_variable = grefm_corinth_1_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d2
+			desc = grefm.144.d2
 			trigger = {
 				has_variable = grefm_corinth_2_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d3
+			desc = grefm.144.d3
 			trigger = {
 				has_variable = grefm_thessaloniki_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d4
+			desc = grefm.144.d4
 			trigger = {
 				has_variable = grefm_thebes_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d5
+			desc = grefm.144.d5
 			trigger = {
 				has_variable = grefm_nicomedia_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d6
+			desc = grefm.144.d6
 			trigger = {
 				has_variable = grefm_smyrna_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d7
+			desc = grefm.144.d7
 			trigger = {
 				has_variable = grefm_tyana_excavation
 			}
 		}
 		triggered_desc = {
-			desc = grefm.143.d8
+			desc = grefm.144.d8
 			trigger = {
 				has_variable = grefm_chios_excavation
 			}
@@ -12478,7 +12485,7 @@ grefm.801 = { # Nova Roma Constantinopolitana
 	flavor = grefm.801.f
 	
 	event_image = {
-		video = "grefm_georgios_averof"
+		video = "byzfm_georgios_averof"
 	}
 	
 	icon = "gfx/interface/icons/event_icons/event_aquila.dds"

--- a/gui/00_vanilla_overwrite.gui
+++ b/gui/00_vanilla_overwrite.gui
@@ -1,0 +1,12 @@
+#############################
+# COMMUNITY FULLSCREEN HIDE #
+#############################
+
+# By Alexedishi
+
+#################
+
+#Replaces the vanilla file with this for compatibility reasons
+template fullscreen_hide {
+    visible = "[Not(Or(Or(Or(Or(Or(Or(InformationPanelBar.IsPanelOpen('politics'), InformationPanelBar.IsPanelOpen('politics_panel_change_law')), InformationPanelBar.IsPanelOpen('tech_tree')), InformationPanelBar.IsPanelOpen('pop_browser')), InformationPanelBar.IsPanelOpen('building_browser')), InformationPanelBar.IsPanelOpen('countries')), GetVariableSystem.Exists('com_fullscreen')))]"
+}

--- a/gui/eocfm_widgets.gui
+++ b/gui/eocfm_widgets.gui
@@ -3,7 +3,6 @@ widget = {
 	parentanchor = top|hcenter
 	size { 100% 100% }
 	layer = layer_ingame_menu
-	
 	visible = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
 	
 	fullscreen_block_window = {
@@ -14,26 +13,7 @@ widget = {
 		
 		datacontext = "[GetPlayer]"
 		
-		visible = "[And( 
-						And( 
-							IsInGame, 
-							And( 
-								Not( IsPauseMenuShown ), 
-								Not( IsGameOverScreenShown )
-							)
-						), 
-						GetVariableSystem.HasValue('com_open_window', 'eocfm_sidebar_button_sgui')
-					)]"
-		
-		state = {
-			name = _show
-			# Toggle doesn't work here as it is still toggled on reload, so I have to set it instead
-			on_finish = "[GetVariableSystem.Set('com_fullscreen', 'com_fullscreen')]" 
-		}
-		state = {
-			name = _hide
-			on_finish = "[GetVariableSystem.Clear('com_fullscreen')]"
-		}
+		visible = "[GetVariableSystem.HasValue('com_open_window', 'eocfm_sidebar_button_sgui')]"
 
 		blockoverride "back_button_fullscreen" {
 			close_button_large = {
@@ -66,8 +46,8 @@ widget = {
 				}
 				start_sound = {
 					soundeffect = "snapshot:/Dynamic/mute_vfx_war_100"
-
 				}
+				on_finish = "[GetVariableSystem.Set( 'com_fullscreen', 'com_fullscreen')]"
 			}
 
 			state = {
@@ -75,6 +55,7 @@ widget = {
 				start_sound = {
 					soundeffect = "event:/SFX/UI/SideBar/society_stop"
 				}
+				on_finish = "[GetVariableSystem.Clear('com_fullscreen')]"
 			}
 		}
 		
@@ -83,7 +64,6 @@ widget = {
 			text = "eocfm_gui_main_title"
 		}
 		
-
 		vbox = {
 			layoutpolicy_vertical = expanding
 			spacing = 5

--- a/localization/english/eocfm_l_english.yml
+++ b/localization/english/eocfm_l_english.yml
@@ -600,7 +600,7 @@
  
  # GUI Button
  eocfm_sidebar_button_sgui: "eocfm_sidebar_button_sgui"
- eocfm_sidebar_button_sgui_desc: "#bold The Orthodox Church#!\n@eocfm_caesaropapism! Balance: #bold #greece [GetPlayer.MakeScope.ScriptValue('eocfm_caesaropapism_capacity_value')]#!#!"
+ eocfm_sidebar_button_sgui_desc: "#bold The Orthodox Church#!"
  
  # GUI Top Bar
  eocfm_gui_main_title: "The Eastern Orthodox Church"

--- a/localization/english/grefm_events_l_english.yml
+++ b/localization/english/grefm_events_l_english.yml
@@ -412,7 +412,7 @@
  grefm.144.t7: "Tyana Excavated"
  grefm.144.d7: "While Tyana was lost to Turkic invasion early in their conquest of Anatolia, this fact hasn't stopped ephors from identifying hundreds of ruins in the old city."
  grefm.144.t8: "Chios Surveyed"
- grefm.144.d9: "Ephors have announced the completion of their survey of the island of Chios. Several ruins have been identified that have secured the island's status as a strategic holding during the Roman era and its subsequent occupation by the Genoese before falling into Ottoman control."
+ grefm.144.d8: "Ephors have announced the completion of their survey of the island of Chios. Several ruins have been identified that have secured the island's status as a strategic holding during the Roman era and its subsequent occupation by the Genoese before falling into Ottoman control."
  grefm.144.f: "With every medieval site explored, [ROOT.GetCountry.GetName] is reminded of how it flourished in the Roman era."
  grefm.144.a: "Fantastic Work!"
  


### PR DESCRIPTION
-Fixed a missing option in grefm.030 if the Bavarocracy is secured
-Updated CRE, CYP, GRE, and ION definitions to be Hellene primary
-Embracing a Greek identity will now disable the other buttons in the Greek Nationalism journal
-Roman excavations events were calling the wrong loc
-Added missing event video to grefm.801 "Nova Rome Constantinopolitana"
-Fixed outliner not being hidden in the Orthodox Widget
-Fixed loc for Orthodoxy button running over other buttons -Fixed country triggers for ideologies